### PR TITLE
Fix return value for resource params

### DIFF
--- a/docs/source/concepts/resource_tree.rst
+++ b/docs/source/concepts/resource_tree.rst
@@ -171,7 +171,7 @@ then, when handling the request:
 .. code-block:: console
 
    $ kapow get /request/params/myparam
-   myparam
+   bar
 
 
 ``/request/headers/<name>`` Resource


### PR DESCRIPTION
In the example, the param name is "myparam" and the value is "bar", but the output for the value is "myparam"...
s/myparam/bar/