### PR TITLE
doc: switch to English MDN page

### DIFF
--- a/docs/source/examples/handling_http_requests.rst
+++ b/docs/source/examples/handling_http_requests.rst
@@ -54,7 +54,7 @@ Testing with :program:`curl`:
 .. note::
 
     You can read more about the ``X-Content-Type-Options: nosniff`` header `here
-    <https://developer.mozilla.org/es/docs/Web/HTTP/Headers/X-Content-Type-Options>`_.
+    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_.
 
 
 Upload Files


### PR DESCRIPTION
Documentation is written in English, stick to also English MDN to be consistent.

---

Hello!
When reading the documentation I have found that this MDN page was the Spanish one. This can be a little confusing for non-Spanish speakers so this PR change it to English version.

Thanks!
